### PR TITLE
Fixed minor theme picker glitch

### DIFF
--- a/app/src/main/java/com/example/smartshower/ThemePickerAdapter.java
+++ b/app/src/main/java/com/example/smartshower/ThemePickerAdapter.java
@@ -157,9 +157,6 @@ public class ThemePickerAdapter extends
         public void onClick(View view) {
             if (mClickListener != null) mClickListener.onItemClick(themeSources.get(getAdapterPosition()));
 
-            cardView.setStrokeWidth(8);
-            cardView.setStrokeColor(context.getResources().getColor(R.color.shower_blue300));
-
             // Remove border from last selected element
             if(lastSelected != null)
             {
@@ -167,6 +164,9 @@ public class ThemePickerAdapter extends
             }
 
             lastSelected = cardView;
+
+            cardView.setStrokeWidth(8);
+            cardView.setStrokeColor(context.getResources().getColor(R.color.shower_blue300));
         }
     }
 


### PR DESCRIPTION
- Fixed theme picker bug when editing in which current theme was not selected
- Added cooldown for shower controls so that the remote shower target does not interfere with the app control
- Removed edit preset button when the preset used for the shower screen is not owned by the user
